### PR TITLE
added google redirect and useState

### DIFF
--- a/src/Login.js
+++ b/src/Login.js
@@ -3,10 +3,11 @@ import { GoogleLogin, GoogleLogout, useGoogleLogin } from "react-google-login";
 import UserProfile from "./UserProfile";
 const clientId = process.env.REACT_APP_CLIENTID;
 const redirectUri = process.env.REDIRECT_URI;
+// added redirect for google api
 
 function Login() {
 
-  
+
   const [username, setusername] = useState("");
   const [useremail, setuseremail] = useState("");
   const [userimage, setuserimage] = useState("");
@@ -36,6 +37,7 @@ function Login() {
     setShowlogoutButton(false);
   };
 
+  // useState for google api
   const { signIn, loaded } = useGoogleLogin({
     onSuccess: onLoginSuccess,
     clientId: clientId,


### PR DESCRIPTION
I used the useGoogleLogin hook to fix the google sign in on the heroku app. It was working locally, but in order for it to work on Heroku I needed to create an authorized redirect callback. I did so by creating a new button and is functionally working in the app and also saving user info. Youngjune pushed this code for me since I was unable to do so due to some local merge issues.